### PR TITLE
Add graceful shutdown to servers

### DIFF
--- a/naming_server/naming_server.py
+++ b/naming_server/naming_server.py
@@ -99,4 +99,17 @@ def size_file(name):
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8000'))
-    app.run(host='0.0.0.0', port=port)
+
+    from werkzeug.serving import make_server
+    import signal
+
+    server = make_server('0.0.0.0', port, app)
+
+    def _shutdown(signum, frame):
+        print(f'Received signal {signum}, shutting down...')
+        server.shutdown()
+
+    signal.signal(signal.SIGINT, _shutdown)
+    signal.signal(signal.SIGTERM, _shutdown)
+
+    server.serve_forever()

--- a/storage_server/storage_server.py
+++ b/storage_server/storage_server.py
@@ -39,4 +39,17 @@ def delete_chunk(chunk_id):
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8000'))
-    app.run(host='0.0.0.0', port=port)
+
+    from werkzeug.serving import make_server
+    import signal
+
+    server = make_server('0.0.0.0', port, app)
+
+    def _shutdown(signum, frame):
+        print(f'Received signal {signum}, shutting down...')
+        server.shutdown()
+
+    signal.signal(signal.SIGINT, _shutdown)
+    signal.signal(signal.SIGTERM, _shutdown)
+
+    server.serve_forever()


### PR DESCRIPTION
## Summary
- handle SIGINT and SIGTERM in naming and storage servers
- stop serving using werkzeug's server.shutdown

## Testing
- `python -m py_compile naming_server/naming_server.py storage_server/storage_server.py client/client.py name_server/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685188f5bd64832998d851bcb3bfe0dd