### PR TITLE
Remove early placeholders

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,3 +1,0 @@
-# Client
-
-This directory provides the client-side utilities used to interact with the distributed file system.

--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,1 +1,0 @@
-"""Client utilities package."""

--- a/client/main.py
+++ b/client/main.py
@@ -1,7 +1,0 @@
-"""Entry point for the Client utilities."""
-
-def main():
-    pass
-
-if __name__ == "__main__":
-    main()

--- a/name_server/README.md
+++ b/name_server/README.md
@@ -1,3 +1,0 @@
-# Name Server
-
-This directory contains the components for the Name Server, which is responsible for directory services and coordination in the distributed file system.

--- a/name_server/__init__.py
+++ b/name_server/__init__.py
@@ -1,1 +1,0 @@
-"""Name Server package."""

--- a/name_server/main.py
+++ b/name_server/main.py
@@ -1,7 +1,0 @@
-"""Entry point for the Name Server component."""
-
-def main():
-    pass
-
-if __name__ == "__main__":
-    main()

--- a/storage_server/README.md
+++ b/storage_server/README.md
@@ -1,3 +1,0 @@
-# Storage Server
-
-This directory houses the Storage Server implementation, which manages data blocks and handles client read/write requests.

--- a/storage_server/__init__.py
+++ b/storage_server/__init__.py
@@ -1,1 +1,0 @@
-"""Storage Server package."""

--- a/storage_server/main.py
+++ b/storage_server/main.py
@@ -1,7 +1,0 @@
-"""Entry point for the Storage Server component."""
-
-def main():
-    pass
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary
- delete early placeholder modules for client, name server, and storage server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a0fb2d908329b2f6757a5c879a48