### PR TITLE
Add default request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ simple **CLI client**.
 - Chunk replication (replica count configurable via environment)
 - Dockerized naming and storage servers
 - Graceful error when storage volumes run out of space
+- Client and naming server requests use a default timeout to avoid hanging
+  connections
 
 ## Running with Docker
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ simple **CLI client**.
 - Chunk replication (replica count configurable via environment)
 - Dockerized naming and storage servers
 - Graceful error when storage volumes run out of space
-- Client and naming server requests use a default timeout to avoid hanging
-  connections
+- Client and naming server requests use a timeout by default to avoid hangs
 
 ## Running with Docker
 

--- a/client/client.py
+++ b/client/client.py
@@ -1,8 +1,10 @@
 import sys
 import os
 import requests
+from requests.exceptions import RequestException, Timeout
 
 NAME_SERVER = os.environ.get('NAME_SERVER', 'http://localhost:8000')
+TIMEOUT = (3.05, 10)
 
 usage = """Usage:
   client.py create <filename> <local_path>
@@ -14,24 +16,50 @@ usage = """Usage:
 def create(filename, local_path):
     with open(local_path, 'r', encoding='utf-8') as f:
         data = f.read()
-    resp = requests.post(f"{NAME_SERVER}/files/{filename}", data=data.encode('utf-8'))
-    print(resp.text)
+    try:
+        resp = requests.post(
+            f"{NAME_SERVER}/files/{filename}",
+            data=data.encode('utf-8'),
+            timeout=TIMEOUT,
+        )
+        print(resp.text)
+    except Timeout:
+        print('request timed out')
+    except RequestException as e:
+        print(f'Error: {e}')
 
 def read(filename, output_path):
-    resp = requests.get(f"{NAME_SERVER}/files/{filename}")
-    if resp.status_code == 200:
-        with open(output_path, 'w', encoding='utf-8') as f:
-            f.write(resp.text)
-    else:
-        print('Error:', resp.text)
+    try:
+        resp = requests.get(f"{NAME_SERVER}/files/{filename}", timeout=TIMEOUT)
+        if resp.status_code == 200:
+            with open(output_path, 'w', encoding='utf-8') as f:
+                f.write(resp.text)
+        else:
+            print('Error:', resp.text)
+    except Timeout:
+        print('request timed out')
+    except RequestException as e:
+        print(f'Error: {e}')
 
 def delete(filename):
-    resp = requests.delete(f"{NAME_SERVER}/files/{filename}")
-    print(resp.text)
+    try:
+        resp = requests.delete(f"{NAME_SERVER}/files/{filename}", timeout=TIMEOUT)
+        print(resp.text)
+    except Timeout:
+        print('request timed out')
+    except RequestException as e:
+        print(f'Error: {e}')
 
 def size(filename):
-    resp = requests.get(f"{NAME_SERVER}/files/{filename}/size")
-    print(resp.text)
+    try:
+        resp = requests.get(
+            f"{NAME_SERVER}/files/{filename}/size", timeout=TIMEOUT
+        )
+        print(resp.text)
+    except Timeout:
+        print('request timed out')
+    except RequestException as e:
+        print(f'Error: {e}')
 
 if __name__ == '__main__':
     if len(sys.argv) < 3:

--- a/naming_server/naming_server.py
+++ b/naming_server/naming_server.py
@@ -3,6 +3,7 @@ import uuid
 import random
 from flask import Flask, request, jsonify, abort
 import requests
+from requests.exceptions import RequestException, Timeout
 
 app = Flask(__name__)
 
@@ -10,6 +11,7 @@ app = Flask(__name__)
 STORAGE_SERVERS = os.environ.get("STORAGE_SERVERS", "").split(",")
 STORAGE_SERVERS = [s.strip() for s in STORAGE_SERVERS if s.strip()]
 REPLICA_COUNT = int(os.environ.get("REPLICA_COUNT", "2"))
+TIMEOUT = (3.05, 10)
 
 files = {}  # filename -> {"chunks": [{"id": id, "servers": [url, ...]}], "size": int}
 
@@ -30,7 +32,11 @@ def create_file(name):
         for server in servers:
             url = f"{server}/chunks/{chunk_id}"
             try:
-                resp = requests.post(url, data=chunk.encode('utf-8'))
+                resp = requests.post(
+                    url,
+                    data=chunk.encode('utf-8'),
+                    timeout=TIMEOUT,
+                )
                 if resp.status_code == 200:
                     stored.append(server)
                 else:
@@ -38,13 +44,19 @@ def create_file(name):
                         f"Failed to store chunk {chunk_id} on {server}: "
                         f"{resp.status_code}"
                     )
-            except Exception as e:
+            except Timeout:
+                print("request timed out")
+            except RequestException as e:
                 print(f"Failed to store chunk {chunk_id} on {server}: {e}")
         if len(stored) < REPLICA_COUNT:
             for server in stored:
                 try:
-                    requests.delete(f"{server}/chunks/{chunk_id}")
-                except Exception:
+                    requests.delete(
+                        f"{server}/chunks/{chunk_id}", timeout=TIMEOUT
+                    )
+                except Timeout:
+                    print("request timed out")
+                except RequestException:
                     pass
             return (
                 jsonify({"error": "Insufficient storage for chunk", "chunk": chunk_id}),
@@ -65,11 +77,14 @@ def read_file(name):
         for server in entry['servers']:
             url = f"{server}/chunks/{entry['id']}"
             try:
-                resp = requests.get(url)
+                resp = requests.get(url, timeout=TIMEOUT)
                 if resp.status_code == 200:
                     chunk_data = resp.text
                     break
-            except Exception:
+            except Timeout:
+                print("request timed out")
+                continue
+            except RequestException:
                 continue
         if chunk_data is None:
             abort(500)
@@ -85,8 +100,10 @@ def delete_file(name):
         for server in entry['servers']:
             url = f"{server}/chunks/{entry['id']}"
             try:
-                requests.delete(url)
-            except Exception as e:
+                requests.delete(url, timeout=TIMEOUT)
+            except Timeout:
+                print("request timed out")
+            except RequestException as e:
                 print(f"Failed to delete chunk {entry['id']} on {server}: {e}")
     return jsonify({'status': 'deleted'})
 


### PR DESCRIPTION
## Summary
- set TIMEOUT in client and naming server
- handle Timeout and RequestException around all HTTP requests
- document request timeout usage

## Testing
- `python -m py_compile client/client.py naming_server/naming_server.py storage_server/storage_server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a1697d4083299c9419a10738cb69